### PR TITLE
[191121] Oauth2.0 로그인 화면 구축 (미완)

### DIFF
--- a/client/src/components/common/Header/index.jsx
+++ b/client/src/components/common/Header/index.jsx
@@ -1,42 +1,51 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import './Header.scss';
-import logo from "../../../assets/images/quickkick-logo.png";
+import logo from '../../../assets/images/quickkick-logo.png';
 
 const Header = () => {
   return (
     <div className="header">
       <div className="header__left">
-        <ServiceLogo/>
+        <ServiceLogo />
       </div>
       <div className="header__right">
-        <NavBar/>
+        <NavBar />
       </div>
     </div>
   );
 };
 
 const ServiceLogo = () => {
-  return (
-    <img className="logo" src={logo} alt="퀵킥 로고"/>
-  );
+  return <img className="logo" src={logo} alt="퀵킥 로고" />;
 };
 
 const NavBar = () => {
+  const [isLogin, setIsLogin] = useState(false);
+
+  useEffect(() => {
+    const cookie = document.cookie.split('=')[1];
+    setIsLogin(cookie === 'true');
+  }, []);
+
   return (
     <nav className="nav-bar">
       <div className="nav-bar__button">Quick Match</div>
       <div className="nav-bar__button">Quick Team</div>
-      <UserIcon className="nav-bar__userInfo"/>
+      {isLogin ? <UserIcon /> : <LoginBtn />}
     </nav>
   );
 };
 
-const UserIcon = (className) => {
+const LoginBtn = () => {
   return (
-    <div className={className}>
-      유저아이콘
+    <div className="nav-bar__userInfo">
+      <a href="http://127.0.0.1:4000/auth/naver">로그인</a>
     </div>
   );
+};
+
+const UserIcon = () => {
+  return <div className="nav-bar__userInfo">로그아웃</div>;
 };
 
 export default Header;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -12,6 +12,7 @@ const naverLoginResult = () => passport.authenticate("naver", {
 
 const successLogin = (req, res) => {
   console.log(req.user);
+  res.cookie('isLogin', 'true');
   res.redirect("http://127.0.0.1:3000");
 };
 


### PR DESCRIPTION
### 관련 이슈
  - #37 - [FE] Oauth2.0 로그인 화면 구축

### 개발 내용 요약
  - 네이버 로그인 성공 시 cookie 발급
  - cookie 결과값을 통해 리액트에서 state값 변경 (true/false)
  - state값에 따라 렌더하는 컴포넌트가 바뀜 (로그인/로그아웃)
  + 아직 jwt가 아닌 그냥 평문으로 cookie를 발급한 부분은 빠른 시일 내에 수정해야함