### PR TITLE
[191201] match페이지 진입 방법에 따른 FilterContext 상태 초기화 변경

### DIFF
--- a/client/src/components/common/Header/index.jsx
+++ b/client/src/components/common/Header/index.jsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
+import { FilterContext } from '../../../contexts/Filter/Context';
+import setFilterContext from '../../../contexts/Filter/setContext';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
 import './Header.scss';
@@ -26,6 +28,9 @@ const ServiceLogo = () => (
 
 const NavBar = () => {
   const [isLogin, setIsLogin] = useState(false);
+  const [filterState, setFilterState] = useContext(FilterContext);
+
+  const handleOnClick = () => setFilterContext.initializeState(setFilterState);
 
   useEffect(() => {
     const cookie = document.cookie.split('=')[1];
@@ -34,12 +39,14 @@ const NavBar = () => {
 
   return (
     <nav className="nav-bar">
-      <div className="nav-bar__button">
-        <Link to="/match">매치 검색</Link>
-      </div>
-      <div className="nav-bar__button">
-        <Link to="/ranking">팀 목록 보기</Link>
-      </div>
+      <Link to="/match">
+        <div className="nav-bar__button" onClick={handleOnClick}>
+          매치 검색
+        </div>
+      </Link>
+      <Link to="/ranking">
+        <div className="nav-bar__button">팀 목록 보기</div>
+      </Link>
       {isLogin ? <UserIcon /> : <LoginBtn />}
     </nav>
   );

--- a/client/src/components/common/MatchFilter/index.jsx
+++ b/client/src/components/common/MatchFilter/index.jsx
@@ -33,22 +33,22 @@ const RegionPicker = () => {
     {
       title: '서남',
       isChecked: filterState.isCheckedSN,
-      handleOnChange: setFilterContext.setCheckedSN.bind(null, setFilterState),
+      handleOnChange: () => setFilterContext.setCheckedSN(setFilterState),
     },
     {
       title: '서북',
       isChecked: filterState.isCheckedSB,
-      handleOnChange: setFilterContext.setCheckedSB.bind(null, setFilterState),
+      handleOnChange: () => setFilterContext.setCheckedSB(setFilterState),
     },
     {
       title: '동북',
       isChecked: filterState.isCheckedDB,
-      handleOnChange: setFilterContext.setCheckedDB.bind(null, setFilterState),
+      handleOnChange: () => setFilterContext.setCheckedDB(setFilterState),
     },
     {
       title: '동남',
       isChecked: filterState.isCheckedDN,
-      handleOnChange: setFilterContext.setCheckedDN.bind(null, setFilterState),
+      handleOnChange: () => setFilterContext.setCheckedDN(setFilterState),
     },
   ];
   return (
@@ -69,10 +69,8 @@ const RegionPicker = () => {
 const TimePicker = () => {
   const [focused, setFocused] = useState(false);
   const [filterState, setFilterState] = useContext(FilterContext);
-  // const handle = setFilterContext.choiceMatchDay.bind(null, setState, {
-  //   matchDay: 1,
-  // });
   const handleChange = setFilterContext.setMatchDay.bind(null, setFilterState);
+
   return (
     <div className="time-picker">
       <SingleDatePicker
@@ -89,10 +87,7 @@ const TimePicker = () => {
 // 랭킹 토글
 const RankSwitch = () => {
   const [filterState, setFilterState] = useContext(FilterContext);
-  const handleChange = setFilterContext.setSimilerRank.bind(
-    null,
-    setFilterState
-  );
+  const handleChange = () => setFilterContext.setSimilerRank(setFilterState);
 
   return (
     <div className="rank-switch">

--- a/client/src/components/home/HomeQuickMatch/index.jsx
+++ b/client/src/components/home/HomeQuickMatch/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './index.scss';
 import { MatchFilter } from '../../common';
 
@@ -7,6 +8,9 @@ const HomeQuickMatch = () => (
     <div className="grid-container">
       <h3 className="home__section-title">원하는 조건의 매치를 찾아보세요!</h3>
       <MatchFilter />
+      <Link to="/match">
+        <button type="button">퀵 매치 !</button>
+      </Link>
     </div>
   </div>
 );

--- a/client/src/contexts/Filter/setContext.js
+++ b/client/src/contexts/Filter/setContext.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 const setFilterContext = {
   setCheckedSN: (setFilterState) => {
     setFilterState((prev) => ({
@@ -34,6 +36,18 @@ const setFilterContext = {
       ...prev,
       isSimilerRank: !prev.isSimilerRank,
     }));
+  },
+  initializeState: (setFilterState) => {
+    setFilterState({
+      isCheckedSN: true,
+      isCheckedSB: true,
+      isCheckedDB: true,
+      isCheckedDN: true,
+      matchDay: moment(),
+      startTime: null,
+      endTime: null,
+      isSimilerRank: false,
+    });
   },
 };
 


### PR DESCRIPTION
### 개발 내용 요약
  - 메인 페이지에서 빠른 검색을 이용하여 친 경우가 아니라면
  - 매치 페이지로 진입 시 FilterContext의 상태값을 초기화 시켜준다
  - 필터의 적용을 ux적인 측면에서 봐라보며 생각해본 결과이다