### PR TITLE
[111203] 더미데이터 수정, seed.js 생성. 매치리스트 불러오는 개수 제한.

### DIFF
--- a/client/src/components/match/MatchList/index.jsx
+++ b/client/src/components/match/MatchList/index.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../common';
 import './index.scss';
 
 const INIT_MATCH_LIST_FETCH_QUERY = `{
-  PendingMatches{
+  PendingMatches(first:30){
     seq
     host{
       seq

--- a/server/dummy-data.js
+++ b/server/dummy-data.js
@@ -230,11 +230,11 @@ const Team = [
       '거칠게 플레이 하지 않습니다. 구두 공장 운영하는 사람들로 이루어져 있습니다.',
   },
   {
-    name: '건국대 아마축구부',
+    name: '팀 언더독스',
     logo: null,
     homeArea: 'KJI',
     introduction:
-      '건국대학교 중앙축구 동아리 아마축구부 입니다. 주로 6:6 풋살을 즐기며 선출 없습니다.',
+      '패배가 예상되는 플레이어들의 모임인 언더독스 축구부 입니다. 주로 6:6 풋살을 즐기며 선출 없습니다.',
   },
   {
     name: 'FS 동대문',
@@ -436,19 +436,24 @@ const Team = [
   },
 ];
 
-const inputUnderDoggsPlayerId = (playerInfo) => {
+const inputUnderDoggsPlayerId = (playerInfo, idx) => {
   if (playerInfo.teamNum !== UNDER_DOGGS_TEAM_NUM) {
-    return DEFAULT_PLAYER_ID;
+    return idx + '';
   }
   return UNDER_DOGGS_PLAYER_ID[playerInfo.name];
 };
 
-const Player = boostCamperInfo.map((playerInfo) => {
+const Player = boostCamperInfo.map((playerInfo, idx) => {
   return {
-    ...playerInfo,
-    playerId: inputUnderDoggsPlayerId(playerInfo),
+    playerId: inputUnderDoggsPlayerId(playerInfo, idx),
+    team: {
+      connect: {
+        seq: playerInfo.teamNum,
+      },
+    },
+    name: playerInfo.name,
     phone: DEFAULT_PHONE_NUMBER,
-    email: DEFAULT_EMAIL,
+    email: DEFAULT_EMAIL + idx,
   };
 });
 
@@ -496,7 +501,7 @@ const checkingOverTime = (hour, min) => {
 const Match = [];
 
 const createMatchData = () => {
-  for (let i = 0; i < 10000; i++) {
+  for (let i = 0; i < 1000; i++) {
     const randomHost = createRandomNumber(25, 1);
     const randomStadium = stardiumSet[createRandomNumber(14, 0)];
     const date = `2020-${createValidDate()}`;
@@ -504,7 +509,11 @@ const createMatchData = () => {
     const randomMinute = createRandomNumber(2, 0) * 30;
     const description = 'this match is...';
     Match.push({
-      host: randomHost,
+      host: {
+        connect: {
+          seq: randomHost,
+        },
+      },
       guest: null,
       stadium: randomStadium.name,
       address: randomStadium.address,
@@ -518,3 +527,5 @@ const createMatchData = () => {
   }
 };
 createMatchData();
+
+module.exports = { Player, Team, Match };

--- a/server/generated/prisma-client/index.d.ts
+++ b/server/generated/prisma-client/index.d.ts
@@ -292,7 +292,32 @@ export interface ClientConstructor<T> {
  * Types
  */
 
-export type Area = "SB" | "SN" | "DN" | "DB";
+export type Area =
+  | "CNO"
+  | "CGS"
+  | "YSN"
+  | "SDG"
+  | "KJI"
+  | "TDM"
+  | "CNG"
+  | "SBK"
+  | "KBK"
+  | "TBG"
+  | "NWN"
+  | "UPG"
+  | "SDM"
+  | "MPO"
+  | "YGC"
+  | "KSS"
+  | "KRO"
+  | "KCN"
+  | "YDP"
+  | "TJK"
+  | "KNK"
+  | "SCO"
+  | "KNM"
+  | "SPA"
+  | "KDG";
 
 export type Result = "HOST" | "GUEST" | "DRAW";
 
@@ -869,10 +894,10 @@ export interface MatchCreateWithoutHostInput {
   guest?: Maybe<TeamCreateOneWithoutMatchingDoneListInput>;
   stadium: String;
   address?: Maybe<String>;
-  area?: Maybe<Area>;
-  date?: Maybe<String>;
-  startTime?: Maybe<String>;
-  endTime?: Maybe<String>;
+  area: Area;
+  date: String;
+  startTime: String;
+  endTime: String;
   description?: Maybe<String>;
   result?: Maybe<Result>;
   appliedLists?: Maybe<ApplyCreateManyWithoutMatchInput>;
@@ -915,14 +940,14 @@ export interface MatchCreateOneWithoutAppliedListsInput {
 
 export interface MatchCreateWithoutAppliedListsInput {
   seq?: Maybe<Int>;
-  host?: Maybe<TeamCreateOneWithoutUploadMatchListInput>;
+  host: TeamCreateOneWithoutUploadMatchListInput;
   guest?: Maybe<TeamCreateOneWithoutMatchingDoneListInput>;
   stadium: String;
   address?: Maybe<String>;
-  area?: Maybe<Area>;
-  date?: Maybe<String>;
-  startTime?: Maybe<String>;
-  endTime?: Maybe<String>;
+  area: Area;
+  date: String;
+  startTime: String;
+  endTime: String;
   description?: Maybe<String>;
   result?: Maybe<Result>;
 }
@@ -954,13 +979,13 @@ export interface MatchCreateManyWithoutGuestInput {
 
 export interface MatchCreateWithoutGuestInput {
   seq?: Maybe<Int>;
-  host?: Maybe<TeamCreateOneWithoutUploadMatchListInput>;
+  host: TeamCreateOneWithoutUploadMatchListInput;
   stadium: String;
   address?: Maybe<String>;
-  area?: Maybe<Area>;
-  date?: Maybe<String>;
-  startTime?: Maybe<String>;
-  endTime?: Maybe<String>;
+  area: Area;
+  date: String;
+  startTime: String;
+  endTime: String;
   description?: Maybe<String>;
   result?: Maybe<Result>;
   appliedLists?: Maybe<ApplyCreateManyWithoutMatchInput>;
@@ -1336,7 +1361,7 @@ export interface MatchUpdateOneWithoutAppliedListsInput {
 }
 
 export interface MatchUpdateWithoutAppliedListsDataInput {
-  host?: Maybe<TeamUpdateOneWithoutUploadMatchListInput>;
+  host?: Maybe<TeamUpdateOneRequiredWithoutUploadMatchListInput>;
   guest?: Maybe<TeamUpdateOneWithoutMatchingDoneListInput>;
   stadium?: Maybe<String>;
   address?: Maybe<String>;
@@ -1348,12 +1373,10 @@ export interface MatchUpdateWithoutAppliedListsDataInput {
   result?: Maybe<Result>;
 }
 
-export interface TeamUpdateOneWithoutUploadMatchListInput {
+export interface TeamUpdateOneRequiredWithoutUploadMatchListInput {
   create?: Maybe<TeamCreateWithoutUploadMatchListInput>;
   update?: Maybe<TeamUpdateWithoutUploadMatchListDataInput>;
   upsert?: Maybe<TeamUpsertWithoutUploadMatchListInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
   connect?: Maybe<TeamWhereUniqueInput>;
 }
 
@@ -1397,7 +1420,7 @@ export interface MatchUpdateWithWhereUniqueWithoutGuestInput {
 }
 
 export interface MatchUpdateWithoutGuestDataInput {
-  host?: Maybe<TeamUpdateOneWithoutUploadMatchListInput>;
+  host?: Maybe<TeamUpdateOneRequiredWithoutUploadMatchListInput>;
   stadium?: Maybe<String>;
   address?: Maybe<String>;
   area?: Maybe<Area>;
@@ -1617,21 +1640,21 @@ export interface TeamUpsertWithoutOnApplyingListInput {
 
 export interface MatchCreateInput {
   seq?: Maybe<Int>;
-  host?: Maybe<TeamCreateOneWithoutUploadMatchListInput>;
+  host: TeamCreateOneWithoutUploadMatchListInput;
   guest?: Maybe<TeamCreateOneWithoutMatchingDoneListInput>;
   stadium: String;
   address?: Maybe<String>;
-  area?: Maybe<Area>;
-  date?: Maybe<String>;
-  startTime?: Maybe<String>;
-  endTime?: Maybe<String>;
+  area: Area;
+  date: String;
+  startTime: String;
+  endTime: String;
   description?: Maybe<String>;
   result?: Maybe<Result>;
   appliedLists?: Maybe<ApplyCreateManyWithoutMatchInput>;
 }
 
 export interface MatchUpdateInput {
-  host?: Maybe<TeamUpdateOneWithoutUploadMatchListInput>;
+  host?: Maybe<TeamUpdateOneRequiredWithoutUploadMatchListInput>;
   guest?: Maybe<TeamUpdateOneWithoutMatchingDoneListInput>;
   stadium?: Maybe<String>;
   address?: Maybe<String>;
@@ -2214,10 +2237,10 @@ export interface Match {
   seq: Int;
   stadium: String;
   address?: String;
-  area?: Area;
-  date?: String;
-  startTime?: String;
-  endTime?: String;
+  area: Area;
+  date: String;
+  startTime: String;
+  endTime: String;
   description?: String;
   result?: Result;
 }
@@ -2758,10 +2781,10 @@ export interface MatchPreviousValues {
   seq: Int;
   stadium: String;
   address?: String;
-  area?: Area;
-  date?: String;
-  startTime?: String;
-  endTime?: String;
+  area: Area;
+  date: String;
+  startTime: String;
+  endTime: String;
   description?: String;
   result?: Result;
 }

--- a/server/generated/prisma-client/prisma-schema.js
+++ b/server/generated/prisma-client/prisma-schema.js
@@ -191,10 +191,31 @@ module.exports = {
       }
 
       enum Area {
-        SB
-        SN
-        DN
-        DB
+        CNO
+        CGS
+        YSN
+        SDG
+        KJI
+        TDM
+        CNG
+        SBK
+        KBK
+        TBG
+        NWN
+        UPG
+        SDM
+        MPO
+        YGC
+        KSS
+        KRO
+        KCN
+        YDP
+        TJK
+        KNK
+        SCO
+        KNM
+        SPA
+        KDG
       }
 
       type BatchPayload {
@@ -205,14 +226,14 @@ module.exports = {
 
       type Match {
         seq: Int!
-        host: Team
+        host: Team!
         guest: Team
         stadium: String!
         address: String
-        area: Area
-        date: String
-        startTime: String
-        endTime: String
+        area: Area!
+        date: String!
+        startTime: String!
+        endTime: String!
         description: String
         result: Result
         appliedLists(
@@ -234,14 +255,14 @@ module.exports = {
 
       input MatchCreateInput {
         seq: Int
-        host: TeamCreateOneWithoutUploadMatchListInput
+        host: TeamCreateOneWithoutUploadMatchListInput!
         guest: TeamCreateOneWithoutMatchingDoneListInput
         stadium: String!
         address: String
-        area: Area
-        date: String
-        startTime: String
-        endTime: String
+        area: Area!
+        date: String!
+        startTime: String!
+        endTime: String!
         description: String
         result: Result
         appliedLists: ApplyCreateManyWithoutMatchInput
@@ -264,27 +285,27 @@ module.exports = {
 
       input MatchCreateWithoutAppliedListsInput {
         seq: Int
-        host: TeamCreateOneWithoutUploadMatchListInput
+        host: TeamCreateOneWithoutUploadMatchListInput!
         guest: TeamCreateOneWithoutMatchingDoneListInput
         stadium: String!
         address: String
-        area: Area
-        date: String
-        startTime: String
-        endTime: String
+        area: Area!
+        date: String!
+        startTime: String!
+        endTime: String!
         description: String
         result: Result
       }
 
       input MatchCreateWithoutGuestInput {
         seq: Int
-        host: TeamCreateOneWithoutUploadMatchListInput
+        host: TeamCreateOneWithoutUploadMatchListInput!
         stadium: String!
         address: String
-        area: Area
-        date: String
-        startTime: String
-        endTime: String
+        area: Area!
+        date: String!
+        startTime: String!
+        endTime: String!
         description: String
         result: Result
         appliedLists: ApplyCreateManyWithoutMatchInput
@@ -295,10 +316,10 @@ module.exports = {
         guest: TeamCreateOneWithoutMatchingDoneListInput
         stadium: String!
         address: String
-        area: Area
-        date: String
-        startTime: String
-        endTime: String
+        area: Area!
+        date: String!
+        startTime: String!
+        endTime: String!
         description: String
         result: Result
         appliedLists: ApplyCreateManyWithoutMatchInput
@@ -334,10 +355,10 @@ module.exports = {
         seq: Int!
         stadium: String!
         address: String
-        area: Area
-        date: String
-        startTime: String
-        endTime: String
+        area: Area!
+        date: String!
+        startTime: String!
+        endTime: String!
         description: String
         result: Result
       }
@@ -467,7 +488,7 @@ module.exports = {
       }
 
       input MatchUpdateInput {
-        host: TeamUpdateOneWithoutUploadMatchListInput
+        host: TeamUpdateOneRequiredWithoutUploadMatchListInput
         guest: TeamUpdateOneWithoutMatchingDoneListInput
         stadium: String
         address: String
@@ -541,7 +562,7 @@ module.exports = {
       }
 
       input MatchUpdateWithoutAppliedListsDataInput {
-        host: TeamUpdateOneWithoutUploadMatchListInput
+        host: TeamUpdateOneRequiredWithoutUploadMatchListInput
         guest: TeamUpdateOneWithoutMatchingDoneListInput
         stadium: String
         address: String
@@ -554,7 +575,7 @@ module.exports = {
       }
 
       input MatchUpdateWithoutGuestDataInput {
-        host: TeamUpdateOneWithoutUploadMatchListInput
+        host: TeamUpdateOneRequiredWithoutUploadMatchListInput
         stadium: String
         address: String
         area: Area
@@ -1907,6 +1928,13 @@ module.exports = {
         rating: Int
       }
 
+      input TeamUpdateOneRequiredWithoutUploadMatchListInput {
+        create: TeamCreateWithoutUploadMatchListInput
+        update: TeamUpdateWithoutUploadMatchListDataInput
+        upsert: TeamUpsertWithoutUploadMatchListInput
+        connect: TeamWhereUniqueInput
+      }
+
       input TeamUpdateOneWithoutMatchingDoneListInput {
         create: TeamCreateWithoutMatchingDoneListInput
         update: TeamUpdateWithoutMatchingDoneListDataInput
@@ -1929,15 +1957,6 @@ module.exports = {
         create: TeamCreateWithoutOnApplyingListInput
         update: TeamUpdateWithoutOnApplyingListDataInput
         upsert: TeamUpsertWithoutOnApplyingListInput
-        delete: Boolean
-        disconnect: Boolean
-        connect: TeamWhereUniqueInput
-      }
-
-      input TeamUpdateOneWithoutUploadMatchListInput {
-        create: TeamCreateWithoutUploadMatchListInput
-        update: TeamUpdateWithoutUploadMatchListDataInput
-        upsert: TeamUpsertWithoutUploadMatchListInput
         delete: Boolean
         disconnect: Boolean
         connect: TeamWhereUniqueInput

--- a/server/resolver.js
+++ b/server/resolver.js
@@ -11,12 +11,13 @@ const resolvers = {
         },
       });
     },
-    PendingMatches: (_, { host }, { prisma }) => {
+    PendingMatches: (_, { host, first }, { prisma }) => {
       return prisma.matches({
         where: {
           host,
           guest: null,
         },
+        first,
       });
     },
     Match: (_, { seq }, { prisma }) => {

--- a/server/schema.graphql
+++ b/server/schema.graphql
@@ -95,7 +95,7 @@ type Stadium {
 
 type Query {
     Matches(seq:Int, area:Area, host:Int): [Match!]
-    PendingMatches(host:Int): [Match!]
+    PendingMatches(host:Int, first: Int): [Match!]
     Match(seq:Int): Match
     Teams(seq: Int): [Team]
     Team(seq:Int): Team

--- a/server/seed.js
+++ b/server/seed.js
@@ -1,0 +1,19 @@
+require('dotenv').config();
+const { Player, Match, Team } = require('./dummy-data');
+const { prisma } = require('./generated/prisma-client');
+
+const seed = async () => {
+  for (let te of Team) {
+    await prisma.createTeam(te);
+  }
+
+  for (let pl of Player) {
+    await prisma.createPlayer(pl);
+  }
+
+  for (let ma of Match) {
+    await prisma.createMatch(ma);
+  }
+};
+
+seed().catch((e) => console.log(e));


### PR DESCRIPTION

### 개발 내용 요약
  - dummy-data.js 수정
  - seed.js 생성하여 데이터 집어넣는 스크립트 작성
  - MatchList component에서 쿼리 불러오는 갯수 30개로 수정
  - first를 받아서 개수를 제한할 수 있도록 graphQL 스키마와 resolver 수정.