### PR TITLE
[191209] 로그인 성공 시 jwt 발급 및 jwt를 해독하는 '/user' api 생성

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -11,6 +11,7 @@ const authRouter = require('./routes/auth');
 const errorRouter = require('./routes/error');
 const createError = require('./middlewares/createError');
 const mailRouter = require('./routes/mail');
+const userRouter = require('./routes/user');
 const server = new GraphQLServer({
   typeDefs: './schema.graphql',
   resolvers,
@@ -32,6 +33,7 @@ app.use(passport.initialize());
 
 app.use('/auth', authRouter);
 app.use('/mail', mailRouter);
+app.use('/user', userRouter);
 server.start(
   {
     port: 4000,

--- a/server/middlewares/passport.js
+++ b/server/middlewares/passport.js
@@ -2,22 +2,38 @@ const passport = require('passport');
 const NaverStrategy = require('passport-naver').Strategy;
 const { env } = process;
 
+const prodClientInfo = {
+  clientID: env.NAVER_CLIENT_ID,
+  clientSecret: env.NAVER_CLIENT_SECRET,
+  callbackURL: env.NAVER_LOGIN_CALLBACK_URL_DEV,
+};
+
+const devClientInfo = {
+  clientID: env.NAVER_CLIENT_ID_DEV,
+  clientSecret: env.NAVER_CLIENT_SECRET_DEV,
+  callbackURL: env.NAVER_LOGIN_CALLBACK_URL_DEV,
+};
+
+const clientInfo = env.NODE_ENV === 'development' ? devClientInfo : prodClientInfo;
+
 passport.serializeUser((user, done) => done(null, user));
 
 passport.deserializeUser((user, done) => done(null, user));
 
 passport.use(
   new NaverStrategy(
-    {
-      clientID: env.NAVER_CLIENT_ID,
-      clientSecret: env.NAVER_CLIENT_SECRET,
-      callbackURL:
-        env.NODE_ENV === 'development'
-          ? env.NAVER_LOGIN_CALLBACK_URL_DEV
-          : env.NAVER_LOGIN_CALLBACK_URL_PROD,
-    },
+    clientInfo,
     (accessToken, refreshToken, profile, done) => {
+      /*
+      QuickKick 회원 DB에 저장되어 있는지 검사하는 부분 필요
+      아래는 임시로 1개의 아이디와의 비교만 하고 있음
+       */
       return done(null, profile);
+      // if (profile.id === '113927503') return done(null, profile);
+      // else {
+      //   console.log('없는 회원입니다');
+      //   return done(null, null);
+      // }
     }
   )
 );

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "graphql-yoga": "^1.18.3",
     "http-errors": "~1.6.3",
     "jade": "~1.11.0",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
     "nodemailer": "^6.3.1",
     "nodemailer-smtp-pool": "^2.8.3",

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,0 +1,15 @@
+const jwt = require('jsonwebtoken');
+const express = require('express');
+const user = express.Router();
+const { env } = process;
+
+user.get('/', (req, res) => {
+  const token = req.cookies.jwt;
+  const userInfo = jwt.verify(token, env.JWT_SECRET);
+  /*
+  QuickKick 회원 DB에 저장되어 있는지 검사하는 부분 필요
+   */
+  res.send(userInfo);
+});
+
+module.exports = user;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -993,7 +993,7 @@ jade@~1.11.0:
     void-elements "~2.0.1"
     with "~4.0.0"
 
-jsonwebtoken@^8.3.0:
+jsonwebtoken@^8.3.0, jsonwebtoken@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==


### PR DESCRIPTION
### 개발 내용 요약 
- jwt의 verify를 확인하는 api인 /user 생성 및 라우터 추가
   - 요청이 들어오면 req.cookies.jwt를 verify한 후 send를 해준다
- jsonwebtoken 모듈 설치
   - 로그인 시 jwt 발급 및 확인을 위한 설치
- 로그인을 위한 prod, dev 버전 naver-client 정보 구분
   - 개발의 편의를 위해 하나의 client를 추가로 더 두어서 병행 운영
- 네이버 로그인 성공시 jwt에 담아 보낼 정보 추가 및 jwt 발급 (미완)
   - 아직 회원정보 DB가 구축되지 않아 DB를 탐색하는 로직이 없으나 탐색 후 추가하면 되는 부분