### PR TITLE
[191209] team정보에 uuid 필드 추가, seed data	변경.

### DIFF
--- a/client/src/components/match/MatchRegistModal/index.jsx
+++ b/client/src/components/match/MatchRegistModal/index.jsx
@@ -268,4 +268,9 @@ TextInputSection.defaultProps = {
   maxlen: undefined,
   required: false,
 };
+DateSection.propTypes = {
+  matchDate: PropTypes.object.isRequired,
+  setMatchDate: PropTypes.func.isRequired,
+};
+
 export default MatchRegistModal;

--- a/server/dummy-data.js
+++ b/server/dummy-data.js
@@ -463,13 +463,24 @@ const Player = boostCamperInfo.map((playerInfo, idx) => {
   };
 });
 
-const createRandomNumber = (limitNum, startNum) => {
-  const limitNumLen = (limitNum + '').length;
-  return (Math.floor(Math.random() * (10 * limitNumLen)) % limitNum) + startNum;
+const createRandomNumber = (min, max) => {
+  //const limitNumLen = (limitNum + '').length;
+  //const limitNumLen = (limitNum + '').length === 1 ? 10 : 100;
+  //return (Math.floor(Math.random() * (10 * limitNumLen)) % limitNum) + startNum;
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min; //최댓값도 포함, 최솟값도 포함
 };
 
 const isValidDate = (month, day) => {
   const createdDate = new Date(2020, month, day);
+  if (createdDate.getMonth() == month && createdDate.getDate() == day) {
+    return true;
+  }
+  return false;
+};
+const isValidDate2019 = (month, day) => {
+  const createdDate = new Date(2019, month, day);
   if (createdDate.getMonth() == month && createdDate.getDate() == day) {
     return true;
   }
@@ -485,12 +496,25 @@ const changeDigitOneToTwo = (numStr) => {
 
 const createValidDate = () => {
   while (true) {
-    const randomMonth = createRandomNumber(12, 1);
+    const randomMonth = Math.random() > 0.5 ? 2 : 1;
     const randomDay = createRandomNumber(31, 1);
     if (isValidDate(randomMonth, randomDay)) {
       return `${changeDigitOneToTwo(randomMonth + '')}-${changeDigitOneToTwo(
         randomDay + ''
       )}`;
+    }
+  }
+};
+
+const createValidDateDecember = () => {
+  while (true) {
+    const randomMonth = 11;
+    const randomDay = createRandomNumber(31, 9);
+
+    if (isValidDate2019(randomMonth, randomDay)) {
+      return `${changeDigitOneToTwo(
+        randomMonth + 1 + ''
+      )}-${changeDigitOneToTwo(randomDay + '')}`;
     }
   }
 };
@@ -513,11 +537,41 @@ const makeMatchAuthor = (teamSeq) => {
 const Match = [];
 
 const createMatchData = () => {
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < 300; i++) {
+    const randomHost = createRandomNumber(25, 1);
+    const randomStadium = stardiumSet[createRandomNumber(14, 0)];
+    const date = `2019-${createValidDateDecember()}`;
+    const randomStartTime = createRandomNumber(22, 6);
+    const randomMinute = createRandomNumber(2, 0) * 30;
+    const description = 'this match is...';
+    const manager = makeMatchAuthor(randomHost) + 1;
+    Match.push({
+      author: {
+        connect: {
+          seq: manager,
+        },
+      },
+      host: {
+        connect: {
+          seq: randomHost,
+        },
+      },
+      guest: null,
+      stadium: randomStadium.name,
+      address: randomStadium.address,
+      area: randomStadium.district,
+      date: date,
+      startTime: `${checkingOverTime(randomStartTime, randomMinute)}`,
+      endTime: `${checkingOverTime(randomStartTime + 1, randomMinute)}`,
+      description: description,
+      result: null,
+    });
+  }
+  for (let j = 0; j < 700; j++) {
     const randomHost = createRandomNumber(25, 1);
     const randomStadium = stardiumSet[createRandomNumber(14, 0)];
     const date = `2020-${createValidDate()}`;
-    const randomStartTime = createRandomNumber(24, 0);
+    const randomStartTime = createRandomNumber(22, 6);
     const randomMinute = createRandomNumber(2, 0) * 30;
     const description = 'this match is...';
     const manager = makeMatchAuthor(randomHost) + 1;

--- a/server/generated/prisma-client/index.d.ts
+++ b/server/generated/prisma-client/index.d.ts
@@ -391,7 +391,9 @@ export type TeamOrderByInput =
   | "lose_ASC"
   | "lose_DESC"
   | "rating_ASC"
-  | "rating_DESC";
+  | "rating_DESC"
+  | "teamUniqueId_ASC"
+  | "teamUniqueId_DESC";
 
 export type MutationType = "CREATED" | "UPDATED" | "DELETED";
 
@@ -563,6 +565,20 @@ export interface TeamWhereInput {
   rating_lte?: Maybe<Int>;
   rating_gt?: Maybe<Int>;
   rating_gte?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
+  teamUniqueId_not?: Maybe<String>;
+  teamUniqueId_in?: Maybe<String[] | String>;
+  teamUniqueId_not_in?: Maybe<String[] | String>;
+  teamUniqueId_lt?: Maybe<String>;
+  teamUniqueId_lte?: Maybe<String>;
+  teamUniqueId_gt?: Maybe<String>;
+  teamUniqueId_gte?: Maybe<String>;
+  teamUniqueId_contains?: Maybe<String>;
+  teamUniqueId_not_contains?: Maybe<String>;
+  teamUniqueId_starts_with?: Maybe<String>;
+  teamUniqueId_not_starts_with?: Maybe<String>;
+  teamUniqueId_ends_with?: Maybe<String>;
+  teamUniqueId_not_ends_with?: Maybe<String>;
   members_every?: Maybe<PlayerWhereInput>;
   members_some?: Maybe<PlayerWhereInput>;
   members_none?: Maybe<PlayerWhereInput>;
@@ -826,6 +842,7 @@ export interface StadiumWhereInput {
 
 export type TeamWhereUniqueInput = AtLeastOne<{
   seq: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
 }>;
 
 export interface ApplyCreateInput {
@@ -849,6 +866,7 @@ export interface TeamCreateWithoutOnApplyingListInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId: String;
   members?: Maybe<PlayerCreateManyWithoutTeamInput>;
   uploadMatchList?: Maybe<MatchCreateManyWithoutHostInput>;
   matchingDoneList?: Maybe<MatchCreateManyWithoutGuestInput>;
@@ -925,6 +943,7 @@ export interface TeamCreateWithoutUploadMatchListInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId: String;
   members?: Maybe<PlayerCreateManyWithoutTeamInput>;
   matchingDoneList?: Maybe<MatchCreateManyWithoutGuestInput>;
   onApplyingList?: Maybe<ApplyCreateManyWithoutTeamInput>;
@@ -980,6 +999,7 @@ export interface TeamCreateWithoutMembersInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId: String;
   uploadMatchList?: Maybe<MatchCreateManyWithoutHostInput>;
   matchingDoneList?: Maybe<MatchCreateManyWithoutGuestInput>;
   onApplyingList?: Maybe<ApplyCreateManyWithoutTeamInput>;
@@ -1020,6 +1040,7 @@ export interface TeamCreateWithoutMatchingDoneListInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId: String;
   members?: Maybe<PlayerCreateManyWithoutTeamInput>;
   uploadMatchList?: Maybe<MatchCreateManyWithoutHostInput>;
   onApplyingList?: Maybe<ApplyCreateManyWithoutTeamInput>;
@@ -1088,6 +1109,7 @@ export interface TeamUpdateWithoutOnApplyingListDataInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
   members?: Maybe<PlayerUpdateManyWithoutTeamInput>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutHostInput>;
   matchingDoneList?: Maybe<MatchUpdateManyWithoutGuestInput>;
@@ -1298,6 +1320,7 @@ export interface TeamUpdateWithoutUploadMatchListDataInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
   members?: Maybe<PlayerUpdateManyWithoutTeamInput>;
   matchingDoneList?: Maybe<MatchUpdateManyWithoutGuestInput>;
   onApplyingList?: Maybe<ApplyUpdateManyWithoutTeamInput>;
@@ -1376,6 +1399,7 @@ export interface TeamUpdateWithoutMembersDataInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutHostInput>;
   matchingDoneList?: Maybe<MatchUpdateManyWithoutGuestInput>;
   onApplyingList?: Maybe<ApplyUpdateManyWithoutTeamInput>;
@@ -1438,6 +1462,7 @@ export interface TeamUpdateWithoutMatchingDoneListDataInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
   members?: Maybe<PlayerUpdateManyWithoutTeamInput>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutHostInput>;
   onApplyingList?: Maybe<ApplyUpdateManyWithoutTeamInput>;
@@ -1958,6 +1983,7 @@ export interface TeamCreateInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId: String;
   members?: Maybe<PlayerCreateManyWithoutTeamInput>;
   uploadMatchList?: Maybe<MatchCreateManyWithoutHostInput>;
   matchingDoneList?: Maybe<MatchCreateManyWithoutGuestInput>;
@@ -1973,6 +1999,7 @@ export interface TeamUpdateInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
   members?: Maybe<PlayerUpdateManyWithoutTeamInput>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutHostInput>;
   matchingDoneList?: Maybe<MatchUpdateManyWithoutGuestInput>;
@@ -1988,6 +2015,7 @@ export interface TeamUpdateManyMutationInput {
   draw?: Maybe<Int>;
   lose?: Maybe<Int>;
   rating?: Maybe<Int>;
+  teamUniqueId?: Maybe<String>;
 }
 
 export interface ApplySubscriptionWhereInput {
@@ -2100,6 +2128,7 @@ export interface Team {
   draw: Int;
   lose: Int;
   rating: Int;
+  teamUniqueId: String;
 }
 
 export interface TeamPromise extends Promise<Team>, Fragmentable {
@@ -2112,6 +2141,7 @@ export interface TeamPromise extends Promise<Team>, Fragmentable {
   draw: () => Promise<Int>;
   lose: () => Promise<Int>;
   rating: () => Promise<Int>;
+  teamUniqueId: () => Promise<String>;
   members: <T = FragmentableArray<Player>>(args?: {
     where?: PlayerWhereInput;
     orderBy?: PlayerOrderByInput;
@@ -2162,6 +2192,7 @@ export interface TeamSubscription
   draw: () => Promise<AsyncIterator<Int>>;
   lose: () => Promise<AsyncIterator<Int>>;
   rating: () => Promise<AsyncIterator<Int>>;
+  teamUniqueId: () => Promise<AsyncIterator<String>>;
   members: <T = Promise<AsyncIterator<PlayerSubscription>>>(args?: {
     where?: PlayerWhereInput;
     orderBy?: PlayerOrderByInput;
@@ -2212,6 +2243,7 @@ export interface TeamNullablePromise
   draw: () => Promise<Int>;
   lose: () => Promise<Int>;
   rating: () => Promise<Int>;
+  teamUniqueId: () => Promise<String>;
   members: <T = FragmentableArray<Player>>(args?: {
     where?: PlayerWhereInput;
     orderBy?: PlayerOrderByInput;
@@ -3157,6 +3189,7 @@ export interface TeamPreviousValues {
   draw: Int;
   lose: Int;
   rating: Int;
+  teamUniqueId: String;
 }
 
 export interface TeamPreviousValuesPromise
@@ -3171,6 +3204,7 @@ export interface TeamPreviousValuesPromise
   draw: () => Promise<Int>;
   lose: () => Promise<Int>;
   rating: () => Promise<Int>;
+  teamUniqueId: () => Promise<String>;
 }
 
 export interface TeamPreviousValuesSubscription
@@ -3185,6 +3219,7 @@ export interface TeamPreviousValuesSubscription
   draw: () => Promise<AsyncIterator<Int>>;
   lose: () => Promise<AsyncIterator<Int>>;
   rating: () => Promise<AsyncIterator<Int>>;
+  teamUniqueId: () => Promise<AsyncIterator<String>>;
 }
 
 /*

--- a/server/generated/prisma-client/prisma-schema.js
+++ b/server/generated/prisma-client/prisma-schema.js
@@ -1646,6 +1646,7 @@ type Team {
   draw: Int!
   lose: Int!
   rating: Int!
+  teamUniqueId: String!
   members(where: PlayerWhereInput, orderBy: PlayerOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Player!]
   uploadMatchList(where: MatchWhereInput, orderBy: MatchOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Match!]
   matchingDoneList(where: MatchWhereInput, orderBy: MatchOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Match!]
@@ -1668,6 +1669,7 @@ input TeamCreateInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String!
   members: PlayerCreateManyWithoutTeamInput
   uploadMatchList: MatchCreateManyWithoutHostInput
   matchingDoneList: MatchCreateManyWithoutGuestInput
@@ -1704,6 +1706,7 @@ input TeamCreateWithoutMatchingDoneListInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String!
   members: PlayerCreateManyWithoutTeamInput
   uploadMatchList: MatchCreateManyWithoutHostInput
   onApplyingList: ApplyCreateManyWithoutTeamInput
@@ -1719,6 +1722,7 @@ input TeamCreateWithoutMembersInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String!
   uploadMatchList: MatchCreateManyWithoutHostInput
   matchingDoneList: MatchCreateManyWithoutGuestInput
   onApplyingList: ApplyCreateManyWithoutTeamInput
@@ -1734,6 +1738,7 @@ input TeamCreateWithoutOnApplyingListInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String!
   members: PlayerCreateManyWithoutTeamInput
   uploadMatchList: MatchCreateManyWithoutHostInput
   matchingDoneList: MatchCreateManyWithoutGuestInput
@@ -1749,6 +1754,7 @@ input TeamCreateWithoutUploadMatchListInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String!
   members: PlayerCreateManyWithoutTeamInput
   matchingDoneList: MatchCreateManyWithoutGuestInput
   onApplyingList: ApplyCreateManyWithoutTeamInput
@@ -1778,6 +1784,8 @@ enum TeamOrderByInput {
   lose_DESC
   rating_ASC
   rating_DESC
+  teamUniqueId_ASC
+  teamUniqueId_DESC
 }
 
 type TeamPreviousValues {
@@ -1790,6 +1798,7 @@ type TeamPreviousValues {
   draw: Int!
   lose: Int!
   rating: Int!
+  teamUniqueId: String!
 }
 
 type TeamSubscriptionPayload {
@@ -1819,6 +1828,7 @@ input TeamUpdateInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String
   members: PlayerUpdateManyWithoutTeamInput
   uploadMatchList: MatchUpdateManyWithoutHostInput
   matchingDoneList: MatchUpdateManyWithoutGuestInput
@@ -1834,6 +1844,7 @@ input TeamUpdateManyMutationInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String
 }
 
 input TeamUpdateOneRequiredWithoutUploadMatchListInput {
@@ -1879,6 +1890,7 @@ input TeamUpdateWithoutMatchingDoneListDataInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String
   members: PlayerUpdateManyWithoutTeamInput
   uploadMatchList: MatchUpdateManyWithoutHostInput
   onApplyingList: ApplyUpdateManyWithoutTeamInput
@@ -1893,6 +1905,7 @@ input TeamUpdateWithoutMembersDataInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String
   uploadMatchList: MatchUpdateManyWithoutHostInput
   matchingDoneList: MatchUpdateManyWithoutGuestInput
   onApplyingList: ApplyUpdateManyWithoutTeamInput
@@ -1907,6 +1920,7 @@ input TeamUpdateWithoutOnApplyingListDataInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String
   members: PlayerUpdateManyWithoutTeamInput
   uploadMatchList: MatchUpdateManyWithoutHostInput
   matchingDoneList: MatchUpdateManyWithoutGuestInput
@@ -1921,6 +1935,7 @@ input TeamUpdateWithoutUploadMatchListDataInput {
   draw: Int
   lose: Int
   rating: Int
+  teamUniqueId: String
   members: PlayerUpdateManyWithoutTeamInput
   matchingDoneList: MatchUpdateManyWithoutGuestInput
   onApplyingList: ApplyUpdateManyWithoutTeamInput
@@ -2033,6 +2048,20 @@ input TeamWhereInput {
   rating_lte: Int
   rating_gt: Int
   rating_gte: Int
+  teamUniqueId: String
+  teamUniqueId_not: String
+  teamUniqueId_in: [String!]
+  teamUniqueId_not_in: [String!]
+  teamUniqueId_lt: String
+  teamUniqueId_lte: String
+  teamUniqueId_gt: String
+  teamUniqueId_gte: String
+  teamUniqueId_contains: String
+  teamUniqueId_not_contains: String
+  teamUniqueId_starts_with: String
+  teamUniqueId_not_starts_with: String
+  teamUniqueId_ends_with: String
+  teamUniqueId_not_ends_with: String
   members_every: PlayerWhereInput
   members_some: PlayerWhereInput
   members_none: PlayerWhereInput
@@ -2052,6 +2081,7 @@ input TeamWhereInput {
 
 input TeamWhereUniqueInput {
   seq: Int
+  teamUniqueId: String
 }
 `
       }

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,8 @@
     "nodemailer-smtp-pool": "^2.8.3",
     "passport": "^0.4.0",
     "passport-naver": "^1.0.6",
-    "prisma-client-lib": "^1.34.10"
+    "prisma-client-lib": "^1.34.10",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "prettier": "^1.19.1"

--- a/server/schema.graphql
+++ b/server/schema.graphql
@@ -8,6 +8,7 @@ type Team {
     draw: Int!
     lose: Int!
     rating: Int!
+    teamUniqueId: String!
     members: [Player!]
     uploadMatchList: [Match!]
     matchingDoneList: [Match!]

--- a/server/seed.js
+++ b/server/seed.js
@@ -1,10 +1,19 @@
-require('dotenv').config();
+require('dotenv').config({
+  path: '../.env.development',
+});
+const uuidv4 = require('uuid/v4');
+
 const { Player, Match, Team } = require('./dummy-data');
 const { prisma } = require('./generated/prisma-client');
 
 const seed = async () => {
   for (let te of Team) {
-    await prisma.createTeam(te);
+    const uid = uuidv4().substr(0, 8);
+    const uuidForTeam = {
+      ...te,
+      teamUniqueId: uid,
+    };
+    await prisma.createTeam(uuidForTeam);
   }
 
   for (let pl of Player) {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1820,7 +1820,7 @@ utils-merge@1.0.1, utils-merge@1.x.x:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.1.0:
+uuid@^3.1.0, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==


### PR DESCRIPTION
### 개발 내용 요약
  - 추후 uuid로 팀 가입을 받을 예정이라 미리 필드에 추가해둠.
  - 그에따라 seed용 dummy 데이터 구조 변경. 매치 날짜도 12월, 1월, 2월에만 올라가도록 수정.
