### PR TITLE
[191215] graphQL 쿼리 인자가 안들어 갔을 때 prisma에서 데이터 올바르게 받아오지 못하던 부분 수정.

### DIFF
--- a/server/resolver.js
+++ b/server/resolver.js
@@ -5,9 +5,11 @@ const resolvers = {
         where: {
           seq,
           area,
-          host: {
-            seq: host,
-          },
+          host: host
+            ? {
+                seq: host,
+              }
+            : undefined,
         },
       });
     },
@@ -46,9 +48,11 @@ const resolvers = {
         where: {
           seq,
           playerId,
-          team: {
-            seq: team,
-          },
+          team: team
+            ? {
+                seq: team,
+              }
+            : undefined,
         },
       });
     },
@@ -61,9 +65,11 @@ const resolvers = {
     Notifiers: (_, { seq, player }, { prisma }) => {
       return prisma.notifiers({
         seq,
-        player: {
-          seq: player,
-        },
+        player: player
+          ? {
+              seq: player,
+            }
+          : undefined,
       });
     },
     Notifier: (_, { seq }, { prisma }) => {
@@ -82,11 +88,13 @@ const resolvers = {
     CreatePlayer: (_, { playerId, team, name, phone, email }, { prisma }) => {
       return prisma.createPlayer({
         playerId,
-        team: {
-          connect: {
-            seq: team,
-          },
-        },
+        team: team
+          ? {
+              connect: {
+                seq: team,
+              },
+            }
+          : null,
         name,
         phone,
         email,


### PR DESCRIPTION

### 개발 내용 요약
  - undefined로 넘어가는 경우 relation 설정된 폴더는 조금 다르게 처리해야함.
  - resolver 함수 긴급한 부분 수정, 추후 mutation까지 전체 검토 해야할 필요 있음.