### PR TITLE
[191216] HOTFIX: jwt 쿠키 httpOnly 옵션 제거

### DIFF
--- a/server/routes/auth/controller.js
+++ b/server/routes/auth/controller.js
@@ -42,8 +42,7 @@ const publishToken = (req, res, next) => {
   const playerId = convertToString(req.user.id);
   const payload = { authProvider, playerId };
   const token = jwt.sign(payload, env.JWT_SECRET);
-  const httpOnly = { httpOnly: true };
-  res.cookie('jwt', token, httpOnly);
+  res.cookie('jwt', token);
   next();
 };
 


### PR DESCRIPTION
### 개발 내용 요약
  - client에서 요청 시 오류가 존재하여 기존의 방식으로 변경