### PR TITLE
[191218] 오타 수정, 소소한 기능 및 graphQL 데이터 스키마 수정.

### DIFF
--- a/client/src/components/common/DateTimeFilter/index.jsx
+++ b/client/src/components/common/DateTimeFilter/index.jsx
@@ -45,11 +45,19 @@ const TimeRangePicker = () => {
   const handleStartTimeChange = (time) => {
     const { hour, minute } = time;
     const newStartTime = `${hour}:${minute}`;
+    if (newStartTime >= endTime) {
+      alert('시작 시간이 종료 시간보다 클 수 없습니다.');
+      return;
+    }
     filterDispatch(FilterActionCreator.setStartTime(newStartTime));
   };
   const handleEndTimeChange = (time) => {
     const { hour, minute } = time;
     const newEndTime = `${hour}:${minute}`;
+    if (newEndTime <= startTime) {
+      alert('시작 시간이 종료 시간보다 클 수 없습니다.');
+      return;
+    }
     filterDispatch(FilterActionCreator.setEndTime(newEndTime));
   };
 

--- a/client/src/views/myteam/index.jsx
+++ b/client/src/views/myteam/index.jsx
@@ -8,7 +8,6 @@ import {
 } from '../../components/myteam';
 import { Redirect } from 'react-router-dom';
 import { UserContext } from '../../contexts/User';
-import ReactSwitch from 'react-switch';
 
 const gql = `
 query ($seq: Int){

--- a/server/generated/prisma-client/index.d.ts
+++ b/server/generated/prisma-client/index.d.ts
@@ -545,6 +545,9 @@ export interface PlayerWhereInput {
   teamCreate_every?: Maybe<TeamWhereInput>;
   teamCreate_some?: Maybe<TeamWhereInput>;
   teamCreate_none?: Maybe<TeamWhereInput>;
+  applyingList_every?: Maybe<ApplyWhereInput>;
+  applyingList_some?: Maybe<ApplyWhereInput>;
+  applyingList_none?: Maybe<ApplyWhereInput>;
   AND?: Maybe<PlayerWhereInput[] | PlayerWhereInput>;
   OR?: Maybe<PlayerWhereInput[] | PlayerWhereInput>;
   NOT?: Maybe<PlayerWhereInput[] | PlayerWhereInput>;
@@ -795,6 +798,7 @@ export interface ApplyWhereInput {
   seq_gt?: Maybe<Int>;
   seq_gte?: Maybe<Int>;
   team?: Maybe<TeamWhereInput>;
+  player?: Maybe<PlayerWhereInput>;
   match?: Maybe<MatchWhereInput>;
   AND?: Maybe<ApplyWhereInput[] | ApplyWhereInput>;
   OR?: Maybe<ApplyWhereInput[] | ApplyWhereInput>;
@@ -868,6 +872,7 @@ export type TeamWhereUniqueInput = AtLeastOne<{
 export interface ApplyCreateInput {
   seq?: Maybe<Int>;
   team?: Maybe<TeamCreateOneWithoutOnApplyingListInput>;
+  player?: Maybe<PlayerCreateOneWithoutApplyingListInput>;
   match?: Maybe<MatchCreateOneWithoutAppliedListsInput>;
 }
 
@@ -908,6 +913,7 @@ export interface PlayerCreateWithoutTeamCreateInput {
   authProvider: Auth;
   notiList?: Maybe<NotifierCreateManyWithoutPlayerInput>;
   uploadMatchList?: Maybe<MatchCreateManyWithoutAuthorInput>;
+  applyingList?: Maybe<ApplyCreateManyWithoutPlayerInput>;
 }
 
 export interface TeamCreateOneWithoutMembersInput {
@@ -968,6 +974,7 @@ export interface PlayerCreateWithoutUploadMatchListInput {
   authProvider: Auth;
   notiList?: Maybe<NotifierCreateManyWithoutPlayerInput>;
   teamCreate?: Maybe<TeamCreateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyCreateManyWithoutPlayerInput>;
 }
 
 export interface NotifierCreateManyWithoutPlayerInput {
@@ -1026,6 +1033,7 @@ export interface PlayerCreateWithoutTeamInput {
   notiList?: Maybe<NotifierCreateManyWithoutPlayerInput>;
   uploadMatchList?: Maybe<MatchCreateManyWithoutAuthorInput>;
   teamCreate?: Maybe<TeamCreateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyCreateManyWithoutPlayerInput>;
 }
 
 export interface MatchCreateManyWithoutAuthorInput {
@@ -1102,6 +1110,25 @@ export interface ApplyCreateManyWithoutMatchInput {
 export interface ApplyCreateWithoutMatchInput {
   seq?: Maybe<Int>;
   team?: Maybe<TeamCreateOneWithoutOnApplyingListInput>;
+  player?: Maybe<PlayerCreateOneWithoutApplyingListInput>;
+}
+
+export interface PlayerCreateOneWithoutApplyingListInput {
+  create?: Maybe<PlayerCreateWithoutApplyingListInput>;
+  connect?: Maybe<PlayerWhereUniqueInput>;
+}
+
+export interface PlayerCreateWithoutApplyingListInput {
+  seq?: Maybe<Int>;
+  playerId: String;
+  team?: Maybe<TeamCreateOneWithoutMembersInput>;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
+  email?: Maybe<String>;
+  authProvider: Auth;
+  notiList?: Maybe<NotifierCreateManyWithoutPlayerInput>;
+  uploadMatchList?: Maybe<MatchCreateManyWithoutAuthorInput>;
+  teamCreate?: Maybe<TeamCreateManyWithoutOwnerInput>;
 }
 
 export interface ApplyCreateManyWithoutTeamInput {
@@ -1111,6 +1138,7 @@ export interface ApplyCreateManyWithoutTeamInput {
 
 export interface ApplyCreateWithoutTeamInput {
   seq?: Maybe<Int>;
+  player?: Maybe<PlayerCreateOneWithoutApplyingListInput>;
   match?: Maybe<MatchCreateOneWithoutAppliedListsInput>;
 }
 
@@ -1157,8 +1185,22 @@ export interface TeamCreateWithoutMatchingDoneListInput {
   onApplyingList?: Maybe<ApplyCreateManyWithoutTeamInput>;
 }
 
+export interface ApplyCreateManyWithoutPlayerInput {
+  create?: Maybe<
+    ApplyCreateWithoutPlayerInput[] | ApplyCreateWithoutPlayerInput
+  >;
+  connect?: Maybe<ApplyWhereUniqueInput[] | ApplyWhereUniqueInput>;
+}
+
+export interface ApplyCreateWithoutPlayerInput {
+  seq?: Maybe<Int>;
+  team?: Maybe<TeamCreateOneWithoutOnApplyingListInput>;
+  match?: Maybe<MatchCreateOneWithoutAppliedListsInput>;
+}
+
 export interface ApplyUpdateInput {
   team?: Maybe<TeamUpdateOneWithoutOnApplyingListInput>;
+  player?: Maybe<PlayerUpdateOneWithoutApplyingListInput>;
   match?: Maybe<MatchUpdateOneWithoutAppliedListsInput>;
 }
 
@@ -1205,6 +1247,7 @@ export interface PlayerUpdateWithoutTeamCreateDataInput {
   authProvider?: Maybe<Auth>;
   notiList?: Maybe<NotifierUpdateManyWithoutPlayerInput>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutAuthorInput>;
+  applyingList?: Maybe<ApplyUpdateManyWithoutPlayerInput>;
 }
 
 export interface TeamUpdateOneWithoutMembersInput {
@@ -1288,6 +1331,7 @@ export interface PlayerUpdateWithoutUploadMatchListDataInput {
   authProvider?: Maybe<Auth>;
   notiList?: Maybe<NotifierUpdateManyWithoutPlayerInput>;
   teamCreate?: Maybe<TeamUpdateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyUpdateManyWithoutPlayerInput>;
 }
 
 export interface NotifierUpdateManyWithoutPlayerInput {
@@ -1479,6 +1523,7 @@ export interface PlayerUpdateWithoutTeamDataInput {
   notiList?: Maybe<NotifierUpdateManyWithoutPlayerInput>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutAuthorInput>;
   teamCreate?: Maybe<TeamUpdateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyUpdateManyWithoutPlayerInput>;
 }
 
 export interface MatchUpdateManyWithoutAuthorInput {
@@ -1610,6 +1655,33 @@ export interface ApplyUpdateWithWhereUniqueWithoutMatchInput {
 
 export interface ApplyUpdateWithoutMatchDataInput {
   team?: Maybe<TeamUpdateOneWithoutOnApplyingListInput>;
+  player?: Maybe<PlayerUpdateOneWithoutApplyingListInput>;
+}
+
+export interface PlayerUpdateOneWithoutApplyingListInput {
+  create?: Maybe<PlayerCreateWithoutApplyingListInput>;
+  update?: Maybe<PlayerUpdateWithoutApplyingListDataInput>;
+  upsert?: Maybe<PlayerUpsertWithoutApplyingListInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<PlayerWhereUniqueInput>;
+}
+
+export interface PlayerUpdateWithoutApplyingListDataInput {
+  playerId?: Maybe<String>;
+  team?: Maybe<TeamUpdateOneWithoutMembersInput>;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
+  email?: Maybe<String>;
+  authProvider?: Maybe<Auth>;
+  notiList?: Maybe<NotifierUpdateManyWithoutPlayerInput>;
+  uploadMatchList?: Maybe<MatchUpdateManyWithoutAuthorInput>;
+  teamCreate?: Maybe<TeamUpdateManyWithoutOwnerInput>;
+}
+
+export interface PlayerUpsertWithoutApplyingListInput {
+  update: PlayerUpdateWithoutApplyingListDataInput;
+  create: PlayerCreateWithoutApplyingListInput;
 }
 
 export interface ApplyUpsertWithWhereUniqueWithoutMatchInput {
@@ -1788,6 +1860,7 @@ export interface ApplyUpdateWithWhereUniqueWithoutTeamInput {
 }
 
 export interface ApplyUpdateWithoutTeamDataInput {
+  player?: Maybe<PlayerUpdateOneWithoutApplyingListInput>;
   match?: Maybe<MatchUpdateOneWithoutAppliedListsInput>;
 }
 
@@ -1865,6 +1938,41 @@ export interface MatchUpsertWithWhereUniqueWithoutAuthorInput {
   where: MatchWhereUniqueInput;
   update: MatchUpdateWithoutAuthorDataInput;
   create: MatchCreateWithoutAuthorInput;
+}
+
+export interface ApplyUpdateManyWithoutPlayerInput {
+  create?: Maybe<
+    ApplyCreateWithoutPlayerInput[] | ApplyCreateWithoutPlayerInput
+  >;
+  delete?: Maybe<ApplyWhereUniqueInput[] | ApplyWhereUniqueInput>;
+  connect?: Maybe<ApplyWhereUniqueInput[] | ApplyWhereUniqueInput>;
+  set?: Maybe<ApplyWhereUniqueInput[] | ApplyWhereUniqueInput>;
+  disconnect?: Maybe<ApplyWhereUniqueInput[] | ApplyWhereUniqueInput>;
+  update?: Maybe<
+    | ApplyUpdateWithWhereUniqueWithoutPlayerInput[]
+    | ApplyUpdateWithWhereUniqueWithoutPlayerInput
+  >;
+  upsert?: Maybe<
+    | ApplyUpsertWithWhereUniqueWithoutPlayerInput[]
+    | ApplyUpsertWithWhereUniqueWithoutPlayerInput
+  >;
+  deleteMany?: Maybe<ApplyScalarWhereInput[] | ApplyScalarWhereInput>;
+}
+
+export interface ApplyUpdateWithWhereUniqueWithoutPlayerInput {
+  where: ApplyWhereUniqueInput;
+  data: ApplyUpdateWithoutPlayerDataInput;
+}
+
+export interface ApplyUpdateWithoutPlayerDataInput {
+  team?: Maybe<TeamUpdateOneWithoutOnApplyingListInput>;
+  match?: Maybe<MatchUpdateOneWithoutAppliedListsInput>;
+}
+
+export interface ApplyUpsertWithWhereUniqueWithoutPlayerInput {
+  where: ApplyWhereUniqueInput;
+  update: ApplyUpdateWithoutPlayerDataInput;
+  create: ApplyCreateWithoutPlayerInput;
 }
 
 export interface PlayerUpsertWithWhereUniqueWithoutTeamInput {
@@ -2184,6 +2292,7 @@ export interface PlayerCreateWithoutNotiListInput {
   authProvider: Auth;
   uploadMatchList?: Maybe<MatchCreateManyWithoutAuthorInput>;
   teamCreate?: Maybe<TeamCreateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyCreateManyWithoutPlayerInput>;
 }
 
 export interface NotifierUpdateInput {
@@ -2210,6 +2319,7 @@ export interface PlayerUpdateWithoutNotiListDataInput {
   authProvider?: Maybe<Auth>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutAuthorInput>;
   teamCreate?: Maybe<TeamUpdateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyUpdateManyWithoutPlayerInput>;
 }
 
 export interface PlayerUpsertWithoutNotiListInput {
@@ -2235,6 +2345,7 @@ export interface PlayerCreateInput {
   notiList?: Maybe<NotifierCreateManyWithoutPlayerInput>;
   uploadMatchList?: Maybe<MatchCreateManyWithoutAuthorInput>;
   teamCreate?: Maybe<TeamCreateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyCreateManyWithoutPlayerInput>;
 }
 
 export interface PlayerUpdateInput {
@@ -2247,6 +2358,7 @@ export interface PlayerUpdateInput {
   notiList?: Maybe<NotifierUpdateManyWithoutPlayerInput>;
   uploadMatchList?: Maybe<MatchUpdateManyWithoutAuthorInput>;
   teamCreate?: Maybe<TeamUpdateManyWithoutOwnerInput>;
+  applyingList?: Maybe<ApplyUpdateManyWithoutPlayerInput>;
 }
 
 export interface PlayerUpdateManyMutationInput {
@@ -2401,6 +2513,7 @@ export interface Apply {
 export interface ApplyPromise extends Promise<Apply>, Fragmentable {
   seq: () => Promise<Int>;
   team: <T = TeamPromise>() => T;
+  player: <T = PlayerPromise>() => T;
   match: <T = MatchPromise>() => T;
 }
 
@@ -2409,6 +2522,7 @@ export interface ApplySubscription
     Fragmentable {
   seq: () => Promise<AsyncIterator<Int>>;
   team: <T = TeamSubscription>() => T;
+  player: <T = PlayerSubscription>() => T;
   match: <T = MatchSubscription>() => T;
 }
 
@@ -2417,6 +2531,7 @@ export interface ApplyNullablePromise
     Fragmentable {
   seq: () => Promise<Int>;
   team: <T = TeamPromise>() => T;
+  player: <T = PlayerPromise>() => T;
   match: <T = MatchPromise>() => T;
 }
 
@@ -2631,6 +2746,15 @@ export interface PlayerPromise extends Promise<Player>, Fragmentable {
     first?: Int;
     last?: Int;
   }) => T;
+  applyingList: <T = FragmentableArray<Apply>>(args?: {
+    where?: ApplyWhereInput;
+    orderBy?: ApplyOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
 }
 
 export interface PlayerSubscription
@@ -2670,6 +2794,15 @@ export interface PlayerSubscription
     first?: Int;
     last?: Int;
   }) => T;
+  applyingList: <T = Promise<AsyncIterator<ApplySubscription>>>(args?: {
+    where?: ApplyWhereInput;
+    orderBy?: ApplyOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
 }
 
 export interface PlayerNullablePromise
@@ -2703,6 +2836,15 @@ export interface PlayerNullablePromise
   teamCreate: <T = FragmentableArray<Team>>(args?: {
     where?: TeamWhereInput;
     orderBy?: TeamOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  applyingList: <T = FragmentableArray<Apply>>(args?: {
+    where?: ApplyWhereInput;
+    orderBy?: ApplyOrderByInput;
     skip?: Int;
     after?: String;
     before?: String;

--- a/server/generated/prisma-client/prisma-schema.js
+++ b/server/generated/prisma-client/prisma-schema.js
@@ -30,6 +30,7 @@ type AggregateTeam {
 type Apply {
   seq: Int!
   team: Team
+  player: Player
   match: Match
 }
 
@@ -42,11 +43,17 @@ type ApplyConnection {
 input ApplyCreateInput {
   seq: Int
   team: TeamCreateOneWithoutOnApplyingListInput
+  player: PlayerCreateOneWithoutApplyingListInput
   match: MatchCreateOneWithoutAppliedListsInput
 }
 
 input ApplyCreateManyWithoutMatchInput {
   create: [ApplyCreateWithoutMatchInput!]
+  connect: [ApplyWhereUniqueInput!]
+}
+
+input ApplyCreateManyWithoutPlayerInput {
+  create: [ApplyCreateWithoutPlayerInput!]
   connect: [ApplyWhereUniqueInput!]
 }
 
@@ -58,10 +65,18 @@ input ApplyCreateManyWithoutTeamInput {
 input ApplyCreateWithoutMatchInput {
   seq: Int
   team: TeamCreateOneWithoutOnApplyingListInput
+  player: PlayerCreateOneWithoutApplyingListInput
+}
+
+input ApplyCreateWithoutPlayerInput {
+  seq: Int
+  team: TeamCreateOneWithoutOnApplyingListInput
+  match: MatchCreateOneWithoutAppliedListsInput
 }
 
 input ApplyCreateWithoutTeamInput {
   seq: Int
+  player: PlayerCreateOneWithoutApplyingListInput
   match: MatchCreateOneWithoutAppliedListsInput
 }
 
@@ -113,6 +128,7 @@ input ApplySubscriptionWhereInput {
 
 input ApplyUpdateInput {
   team: TeamUpdateOneWithoutOnApplyingListInput
+  player: PlayerUpdateOneWithoutApplyingListInput
   match: MatchUpdateOneWithoutAppliedListsInput
 }
 
@@ -124,6 +140,17 @@ input ApplyUpdateManyWithoutMatchInput {
   disconnect: [ApplyWhereUniqueInput!]
   update: [ApplyUpdateWithWhereUniqueWithoutMatchInput!]
   upsert: [ApplyUpsertWithWhereUniqueWithoutMatchInput!]
+  deleteMany: [ApplyScalarWhereInput!]
+}
+
+input ApplyUpdateManyWithoutPlayerInput {
+  create: [ApplyCreateWithoutPlayerInput!]
+  delete: [ApplyWhereUniqueInput!]
+  connect: [ApplyWhereUniqueInput!]
+  set: [ApplyWhereUniqueInput!]
+  disconnect: [ApplyWhereUniqueInput!]
+  update: [ApplyUpdateWithWhereUniqueWithoutPlayerInput!]
+  upsert: [ApplyUpsertWithWhereUniqueWithoutPlayerInput!]
   deleteMany: [ApplyScalarWhereInput!]
 }
 
@@ -140,15 +167,27 @@ input ApplyUpdateManyWithoutTeamInput {
 
 input ApplyUpdateWithoutMatchDataInput {
   team: TeamUpdateOneWithoutOnApplyingListInput
+  player: PlayerUpdateOneWithoutApplyingListInput
+}
+
+input ApplyUpdateWithoutPlayerDataInput {
+  team: TeamUpdateOneWithoutOnApplyingListInput
+  match: MatchUpdateOneWithoutAppliedListsInput
 }
 
 input ApplyUpdateWithoutTeamDataInput {
+  player: PlayerUpdateOneWithoutApplyingListInput
   match: MatchUpdateOneWithoutAppliedListsInput
 }
 
 input ApplyUpdateWithWhereUniqueWithoutMatchInput {
   where: ApplyWhereUniqueInput!
   data: ApplyUpdateWithoutMatchDataInput!
+}
+
+input ApplyUpdateWithWhereUniqueWithoutPlayerInput {
+  where: ApplyWhereUniqueInput!
+  data: ApplyUpdateWithoutPlayerDataInput!
 }
 
 input ApplyUpdateWithWhereUniqueWithoutTeamInput {
@@ -160,6 +199,12 @@ input ApplyUpsertWithWhereUniqueWithoutMatchInput {
   where: ApplyWhereUniqueInput!
   update: ApplyUpdateWithoutMatchDataInput!
   create: ApplyCreateWithoutMatchInput!
+}
+
+input ApplyUpsertWithWhereUniqueWithoutPlayerInput {
+  where: ApplyWhereUniqueInput!
+  update: ApplyUpdateWithoutPlayerDataInput!
+  create: ApplyCreateWithoutPlayerInput!
 }
 
 input ApplyUpsertWithWhereUniqueWithoutTeamInput {
@@ -178,6 +223,7 @@ input ApplyWhereInput {
   seq_gt: Int
   seq_gte: Int
   team: TeamWhereInput
+  player: PlayerWhereInput
   match: MatchWhereInput
   AND: [ApplyWhereInput!]
   OR: [ApplyWhereInput!]
@@ -1155,6 +1201,7 @@ type Player {
   notiList(where: NotifierWhereInput, orderBy: NotifierOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Notifier!]
   uploadMatchList(where: MatchWhereInput, orderBy: MatchOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Match!]
   teamCreate(where: TeamWhereInput, orderBy: TeamOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Team!]
+  applyingList(where: ApplyWhereInput, orderBy: ApplyOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Apply!]
 }
 
 type PlayerConnection {
@@ -1174,11 +1221,17 @@ input PlayerCreateInput {
   notiList: NotifierCreateManyWithoutPlayerInput
   uploadMatchList: MatchCreateManyWithoutAuthorInput
   teamCreate: TeamCreateManyWithoutOwnerInput
+  applyingList: ApplyCreateManyWithoutPlayerInput
 }
 
 input PlayerCreateManyWithoutTeamInput {
   create: [PlayerCreateWithoutTeamInput!]
   connect: [PlayerWhereUniqueInput!]
+}
+
+input PlayerCreateOneWithoutApplyingListInput {
+  create: PlayerCreateWithoutApplyingListInput
+  connect: PlayerWhereUniqueInput
 }
 
 input PlayerCreateOneWithoutNotiListInput {
@@ -1196,6 +1249,19 @@ input PlayerCreateOneWithoutUploadMatchListInput {
   connect: PlayerWhereUniqueInput
 }
 
+input PlayerCreateWithoutApplyingListInput {
+  seq: Int
+  playerId: String!
+  team: TeamCreateOneWithoutMembersInput
+  name: String
+  phone: String
+  email: String
+  authProvider: Auth!
+  notiList: NotifierCreateManyWithoutPlayerInput
+  uploadMatchList: MatchCreateManyWithoutAuthorInput
+  teamCreate: TeamCreateManyWithoutOwnerInput
+}
+
 input PlayerCreateWithoutNotiListInput {
   seq: Int
   playerId: String!
@@ -1206,6 +1272,7 @@ input PlayerCreateWithoutNotiListInput {
   authProvider: Auth!
   uploadMatchList: MatchCreateManyWithoutAuthorInput
   teamCreate: TeamCreateManyWithoutOwnerInput
+  applyingList: ApplyCreateManyWithoutPlayerInput
 }
 
 input PlayerCreateWithoutTeamCreateInput {
@@ -1218,6 +1285,7 @@ input PlayerCreateWithoutTeamCreateInput {
   authProvider: Auth!
   notiList: NotifierCreateManyWithoutPlayerInput
   uploadMatchList: MatchCreateManyWithoutAuthorInput
+  applyingList: ApplyCreateManyWithoutPlayerInput
 }
 
 input PlayerCreateWithoutTeamInput {
@@ -1230,6 +1298,7 @@ input PlayerCreateWithoutTeamInput {
   notiList: NotifierCreateManyWithoutPlayerInput
   uploadMatchList: MatchCreateManyWithoutAuthorInput
   teamCreate: TeamCreateManyWithoutOwnerInput
+  applyingList: ApplyCreateManyWithoutPlayerInput
 }
 
 input PlayerCreateWithoutUploadMatchListInput {
@@ -1242,6 +1311,7 @@ input PlayerCreateWithoutUploadMatchListInput {
   authProvider: Auth!
   notiList: NotifierCreateManyWithoutPlayerInput
   teamCreate: TeamCreateManyWithoutOwnerInput
+  applyingList: ApplyCreateManyWithoutPlayerInput
 }
 
 type PlayerEdge {
@@ -1375,6 +1445,7 @@ input PlayerUpdateInput {
   notiList: NotifierUpdateManyWithoutPlayerInput
   uploadMatchList: MatchUpdateManyWithoutAuthorInput
   teamCreate: TeamUpdateManyWithoutOwnerInput
+  applyingList: ApplyUpdateManyWithoutPlayerInput
 }
 
 input PlayerUpdateManyDataInput {
@@ -1424,6 +1495,15 @@ input PlayerUpdateOneRequiredWithoutUploadMatchListInput {
   connect: PlayerWhereUniqueInput
 }
 
+input PlayerUpdateOneWithoutApplyingListInput {
+  create: PlayerCreateWithoutApplyingListInput
+  update: PlayerUpdateWithoutApplyingListDataInput
+  upsert: PlayerUpsertWithoutApplyingListInput
+  delete: Boolean
+  disconnect: Boolean
+  connect: PlayerWhereUniqueInput
+}
+
 input PlayerUpdateOneWithoutTeamCreateInput {
   create: PlayerCreateWithoutTeamCreateInput
   update: PlayerUpdateWithoutTeamCreateDataInput
@@ -1431,6 +1511,18 @@ input PlayerUpdateOneWithoutTeamCreateInput {
   delete: Boolean
   disconnect: Boolean
   connect: PlayerWhereUniqueInput
+}
+
+input PlayerUpdateWithoutApplyingListDataInput {
+  playerId: String
+  team: TeamUpdateOneWithoutMembersInput
+  name: String
+  phone: String
+  email: String
+  authProvider: Auth
+  notiList: NotifierUpdateManyWithoutPlayerInput
+  uploadMatchList: MatchUpdateManyWithoutAuthorInput
+  teamCreate: TeamUpdateManyWithoutOwnerInput
 }
 
 input PlayerUpdateWithoutNotiListDataInput {
@@ -1442,6 +1534,7 @@ input PlayerUpdateWithoutNotiListDataInput {
   authProvider: Auth
   uploadMatchList: MatchUpdateManyWithoutAuthorInput
   teamCreate: TeamUpdateManyWithoutOwnerInput
+  applyingList: ApplyUpdateManyWithoutPlayerInput
 }
 
 input PlayerUpdateWithoutTeamCreateDataInput {
@@ -1453,6 +1546,7 @@ input PlayerUpdateWithoutTeamCreateDataInput {
   authProvider: Auth
   notiList: NotifierUpdateManyWithoutPlayerInput
   uploadMatchList: MatchUpdateManyWithoutAuthorInput
+  applyingList: ApplyUpdateManyWithoutPlayerInput
 }
 
 input PlayerUpdateWithoutTeamDataInput {
@@ -1464,6 +1558,7 @@ input PlayerUpdateWithoutTeamDataInput {
   notiList: NotifierUpdateManyWithoutPlayerInput
   uploadMatchList: MatchUpdateManyWithoutAuthorInput
   teamCreate: TeamUpdateManyWithoutOwnerInput
+  applyingList: ApplyUpdateManyWithoutPlayerInput
 }
 
 input PlayerUpdateWithoutUploadMatchListDataInput {
@@ -1475,11 +1570,17 @@ input PlayerUpdateWithoutUploadMatchListDataInput {
   authProvider: Auth
   notiList: NotifierUpdateManyWithoutPlayerInput
   teamCreate: TeamUpdateManyWithoutOwnerInput
+  applyingList: ApplyUpdateManyWithoutPlayerInput
 }
 
 input PlayerUpdateWithWhereUniqueWithoutTeamInput {
   where: PlayerWhereUniqueInput!
   data: PlayerUpdateWithoutTeamDataInput!
+}
+
+input PlayerUpsertWithoutApplyingListInput {
+  update: PlayerUpdateWithoutApplyingListDataInput!
+  create: PlayerCreateWithoutApplyingListInput!
 }
 
 input PlayerUpsertWithoutNotiListInput {
@@ -1582,6 +1683,9 @@ input PlayerWhereInput {
   teamCreate_every: TeamWhereInput
   teamCreate_some: TeamWhereInput
   teamCreate_none: TeamWhereInput
+  applyingList_every: ApplyWhereInput
+  applyingList_some: ApplyWhereInput
+  applyingList_none: ApplyWhereInput
   AND: [PlayerWhereInput!]
   OR: [PlayerWhereInput!]
   NOT: [PlayerWhereInput!]

--- a/server/prisma/datamodel.prisma
+++ b/server/prisma/datamodel.prisma
@@ -27,6 +27,7 @@ type Player {
     notiList: [Notifier!] @relation(name: "NotiPlayer")
     uploadMatchList: [Match!] @relation(name: "MatchAuthor")
     teamCreate: [Team] @relation(name: "TeamOwner")
+    applyingList: [Apply] @relation(name: "ApplyingPlayer")
 }
 enum Auth {
     KAKAO
@@ -90,6 +91,7 @@ enum Status {
 type Apply{
     seq: Int! @id
     team: Team @relation(link:INLINE, name: "ApplyingTeam")
+    player: Player @relation(link:INLINE, name: "ApplyingPlayer")
     match: Match @relation(link:INLINE, name: "AppliedMatch")
 }
 

--- a/server/resolver.js
+++ b/server/resolver.js
@@ -186,6 +186,25 @@ const resolvers = {
         },
       });
     },
+    ApplyMatch: (_, { team, player, match }, { prisma }) => {
+      return prisma.createApply({
+        team: {
+          connect: {
+            seq: team,
+          },
+        },
+        match: {
+          connect: {
+            seq: match,
+          },
+        },
+        player: {
+          connect: {
+            playerId: player,
+          },
+        },
+      });
+    },
   }, // mutation
   Match: {
     author: ({ seq }, _, { prisma }) => {
@@ -232,6 +251,17 @@ const resolvers = {
   Notifier: {
     player: ({ seq }, _, { prisma }) => {
       return prisma.player({ seq });
+    },
+  },
+  Apply: {
+    team: ({ seq }, _, { prisma }) => {
+      return prisma.apply({ seq }).team();
+    },
+    player: ({ seq }, _, { prisma }) => {
+      return prisma.apply({ seq }).player();
+    },
+    match: ({ seq }, _, { prisma }) => {
+      return prisma.apply({ seq }).match();
     },
   },
 };

--- a/server/schema.graphql
+++ b/server/schema.graphql
@@ -26,6 +26,8 @@ type Player {
     authProvider: Auth!
     notiList: [Notifier!]
     uploadMatchList: [Match!]
+    teamCreate: [Team]
+    applyingList: [Apply]
 }
 enum Auth {
     KAKAO
@@ -89,6 +91,7 @@ enum Status {
 type Apply{
     seq: Int!
     team: Team
+    player: Player
     match: Match
 }
 
@@ -126,5 +129,6 @@ type Mutation {
     MatchGuest(seq: Int, guest: Int): Match
     CreateNotifier(player:Int, area:[Area], date:String, startTime: String, endTime: String): Notifier
     UpdateTeamInfo(seq: Int, name: String, logo: String, homeArea: Area, introduction: String): Team
+    ApplyMatch(team: Int, player:String, match: Int): Apply
 
 }


### PR DESCRIPTION
### 개발 내용 요약
  - 잘못들어간 import 구문 삭제
  - dateTimeFilter에서 시작 시간이 종료 시간보다 크거나 같을 시 alert띄우도록 함.
  - 매치 신청시 DB에 들어갈 데이터 스키마 수정. 매치 신청한 팀 정보만 들어가는 것이 아니고, 신청한 사람의 정보까지 들어가도록 함.(서로 연락해서 확실히 매치 상대를 정할 수 있도록)